### PR TITLE
Correct YIQ conversion, and YIQ#to_rgb

### DIFF
--- a/lib/color/rgb.rb
+++ b/lib/color/rgb.rb
@@ -1,3 +1,5 @@
+require 'matrix'
+
 # An RGB colour object.
 class Color::RGB
   include Color
@@ -228,6 +230,14 @@ class Color::RGB
     i = (@r * 0.596) + (@g * -0.275) + (@b * -0.321)
     q = (@r * 0.212) + (@g * -0.523) + (@b *  0.311)
     Color::YIQ.from_fraction(y, i, q)
+  end
+
+  # Returns the YIQ (NTSC) colour encoding of the RGB value. I and Q scaled to 0..1
+  def to_correct_yiq
+    conversion_matrix = Matrix[[0.299000,  0.587000,  0.114000],
+                               [0.595716, -0.274453, -0.321263],
+                               [0.211456, -0.522591,  0.311135]]
+    Color::YIQ.from_ntsc_fraction( *(conversion_matrix * Matrix.column_vector(self.to_a)).column(0).to_a )
   end
 
   # Returns the HSL colour encoding of the RGB value. The conversions here

--- a/lib/color/yiq.rb
+++ b/lib/color/yiq.rb
@@ -1,12 +1,23 @@
+require 'matrix'
+
 # A colour object representing YIQ (NTSC) colour encoding.
 class Color::YIQ
   include Color
+
+  I_MAX = 0.5957
+  Q_MAX = 0.5226
 
   # Creates a YIQ colour object from fractional values 0 .. 1.
   #
   #   Color::YIQ.new(0.3, 0.2, 0.1)
   def self.from_fraction(y = 0, i = 0, q = 0, &block)
     new(y, i, q, 1.0, &block)
+  end
+
+  # Creates a YIQ colour object from NTSC ranges: Y = 0..1, I = -0.5957..0.5957, Q = -0.5226..0.5226
+  def self.from_ntsc_fraction(y = 0, i = 0, q = 0)
+    # Linear interpolation to 0..1
+    from_fraction(y, (i + I_MAX) / (I_MAX * 2), (q + Q_MAX) / (Q_MAX * 2))
   end
 
   # Creates a YIQ colour object from percentages 0 .. 100.
@@ -59,4 +70,17 @@ class Color::YIQ
   def to_a
     [ y, i, q ]
   end
+
+  def to_ntsc
+    # Linear interpolation of I and Q to -I_MAX..I_MAX, -Q_MAX..Q_MAX
+    [@y, (@i * 2 * I_MAX) - I_MAX, (@q * 2 * Q_MAX) - Q_MAX]
+  end
+
+  def to_rgb
+    conversion_matrix = Matrix[[1,  0.9563,  0.6210],
+                               [1, -0.2721, -0.6474],
+                               [1, -1.1070,  1.7046]]
+    Color::RGB.from_fraction( *(conversion_matrix * Matrix.column_vector(self.to_ntsc)).column(0).to_a )
+  end
+
 end


### PR DESCRIPTION
This patch fixes RGB=>YIQ conversion, and provides YIQ=>RGB conversion. I'd love to replace to_yiq, but this would break existing clients. This seems like a reasonable compromise, but I'm open to other ideas.

You can verify these conversions using http://www.picturetopeople.org/color_converter.html. The Wikipedia article on YIQ also notes these ranges: http://en.wikipedia.org/wiki/YIQ. (I'm using the same numbers you are, just at higher precision.)

In YIQ, only Y is in the 0..1 range, I and Q have a different min/max.
In this change:
- RGB::to_correct_yiq will correctly re-scale and accurately convert
  I/Q.
- Adds YIQ.from_ntsc_fraction and YIQ#to_ntsc to rescale to and from
  the 0..1 range into the actual range.
- Adds YIQ#to_rgb to enable going back to RGB from YIQ.
- Uses stdlib matrix for conversion.
