### PR TITLE
Adds an optional alpha parameter to the css_rgba method.

### DIFF
--- a/lib/color/rgb.rb
+++ b/lib/color/rgb.rb
@@ -59,11 +59,11 @@ class Color::RGB
     "rgb(%3.2f%%, %3.2f%%, %3.2f%%)" % [ red_p, green_p, blue_p ]
   end
 
-  # Present the colour as an RGBA (with alpha) HTML/CSS colour string (e.g.,
-  # "rgb(0%, 50%, 100%, 1)"). Note that this will perform a #to_rgb
-  # operation using the default conversion formula.
-  def css_rgba
-    "rgba(%3.2f%%, %3.2f%%, %3.2f%%, %3.2f)" % [ red_p, green_p, blue_p, 1 ]
+  # Present the colour as an RGBA (with an optional alpha that defaults to 1)
+  # HTML/CSS colour string (e.g.,"rgb(0%, 50%, 100%, 1)"). Note that this will
+  # perform a #to_rgb operation using the default conversion formula.
+  def css_rgba(alpha = 1)
+    "rgba(%3.2f%%, %3.2f%%, %3.2f%%, %3.2f)" % [ red_p, green_p, blue_p, alpha ]
   end
 
   # Present the colour as an HSL HTML/CSS colour string (e.g., "hsl(180,

--- a/test/test_rgb.rb
+++ b/test/test_rgb.rb
@@ -93,6 +93,7 @@ module TestColor
       assert_equal("rgba(100.00%, 0.00%, 0.00%, 1.00)", Color::RGB::Red.css_rgba)
       assert_equal("rgba(100.00%, 100.00%, 100.00%, 1.00)",
                    Color::RGB::White.css_rgba)
+      assert_equal("rgba(100.00%, 0.00%, 0.00%, 0.50)", Color::RGB::Red.css_rgba(0.5))
     end
 
     def test_lighten_by


### PR DESCRIPTION
In order to resolve a transparency issue that arose through using a hex based value, I used your gem to convert the hex to RGB.

Though the gem offered one method for converting to percentage based integers, the alpha was hard coded to 1 and I required 0.6. On this basis I added an optional alpha parameter that defaults to 1.

I hope you find this useful :)