### PR TITLE
Updates Color::RGB.closest_match to use the newer CIEDE2000 algorithm.

### DIFF
--- a/test/test_rgb.rb
+++ b/test/test_rgb.rb
@@ -298,10 +298,10 @@ module TestColor
       # But fails if using the :just_noticeable difference.
       assert_nil(Color::RGB::Indigo.closest_match(match_from, :just_noticeable))
 
-      # Crimson & Firebrick are visually closer than DarkRed and Firebrick
+      # DarkRed & Firebrick are visually closer than Crimson and Firebrick
       # (more precise match)
       match_from += [Color::RGB::DarkRed, Color::RGB::Crimson]
-      assert_equal(Color::RGB::Crimson,
+      assert_equal(Color::RGB::DarkRed,
                    Color::RGB::Firebrick.closest_match(match_from))
       # Specifying a threshold low enough will cause even that match to
       # fail, though.
@@ -316,6 +316,13 @@ module TestColor
       # And then something that's just barely out of the tolerance range
       diff_green = Color::RGB.new(9, 142, 9)
       assert_nil(diff_green.closest_match(match_from, :jnd))
+
+      # It should match a very dark Blue to Black instead of MidnightBlue
+      # (this is something CIE94 is not good at)
+      almost_black = Color::RGB.new(41, 33, 44)
+      match_from += [Color::RGB::MidnightBlue, Color::RGB::Black]
+      assert_equal(Color::RGB::Black,
+                   almost_black.closest_match(match_from))
     end
 
     def test_add


### PR DESCRIPTION
This implements the newer CIEDE2000 color difference algorithm for use with `Color::RGB.closest_match`. The Wikipedia article on [Color Difference](http://en.wikipedia.org/wiki/Color_difference#CIEDE2000) outlines the benefits of this algorithm over the older CIE94 version. The main benefit is that it compensates for some inconsistencies in the blue region.

To implement this I used the implementation steps from [this research document](http://www.ece.rochester.edu/~gsharma/ciede2000/ciede2000noteCRNA.pdf), and I matched all the lines back to the numbers outlined in the document. This should, hopefully, make it a little easier to follow.

I do not claim to be an expert on color theory, but I'm fairly confident that I implemented this algorithm correctly. I've done a lot of manual testing as well as automated testing, and so far it is surpasses or is comparable to the CIE94 version in all respects.

Again, the main benefit of this the blue region. Color set that I found particularly bad with the CIE94 version is _very_ dark blues that appear black, but were mapping to a Midnight Blue color instead. This version of the algorithm fixes the problem. Here's an example:

This color (#29212C):
![screen shot 2015-01-20 at 4 40 53 pm](https://cloud.githubusercontent.com/assets/174227/5829193/490b5e3a-a0c3-11e4-9773-7335fb916f5d.png)

When given these two colors to find as its _closest match_:
Black (#000000):
![screen shot 2015-01-20 at 4 41 12 pm](https://cloud.githubusercontent.com/assets/174227/5829199/649b9750-a0c3-11e4-8e0c-d2aca390c6ad.png)

MidnightBlue (#191970):
![screen shot 2015-01-20 at 4 41 46 pm](https://cloud.githubusercontent.com/assets/174227/5829205/75d02892-a0c3-11e4-9731-2a611b7846a4.png)

With the CIE94 algorithm it matches to MidnightBlue. With the CIEDE2000 algorithm it matches to Black instead (which is visually correct).

I also had to update the test that was matching Firebrick to Crimson when given the choice between Crimson and DarkRed. The CIEDE2000 algorithm matches it to DarkRed instead of Crimson, which, in my opinion at least, is a very slightly closer visual match.

Firebrick:
![screen shot 2015-01-20 at 4 46 39 pm](https://cloud.githubusercontent.com/assets/174227/5829237/f928237a-a0c3-11e4-83d3-02281d3debca.png)

DarkRed:
![screen shot 2015-01-20 at 4 46 46 pm](https://cloud.githubusercontent.com/assets/174227/5829239/fe2d8b80-a0c3-11e4-8802-255b8a419c18.png)

Crimson:
![screen shot 2015-01-20 at 4 46 54 pm](https://cloud.githubusercontent.com/assets/174227/5829240/033406fe-a0c4-11e4-8fbd-496a7e213411.png)
