### PR TITLE
Update step-security/harden-runner to v2.14.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -157,7 +157,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -206,7 +206,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -251,7 +251,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -298,7 +298,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: block
           disable-sudo: true

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           egress-policy: audit
 

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Harden the runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        uses: step-security/harden-runner@5ef0c079ce82195b2a36a210272d6b661572d83e # v2.14.2
         with:
           disable-sudo: true
           egress-policy: block

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # color Changelog
 
+## 2.2.0 / 2026-01-DD
+
+- When `color/rgb/colors` is loaded and the RGB color does not have defined
+  names, a fallback lookup to named RGB colors will be performed to use that
+  name.
+
+  ```ruby
+  simple_black = Color.from_values(r: 0, g: 0, b: 0)
+  stuart_black = Color.from_values(r: 0, g: 0, b: 0, names: ["semple-black-4.0"])
+
+  simple_black.name # => nil
+  stuart_black.name # => "semple-black-4.0"
+
+  require 'color/rgb/colors'
+
+  simple_black.name # => "black"
+  stuart_black.name # => "semple-black-4.0"
+  ```
+
+  This was suggested by [@akicho8][gh-user-akicho8] in [#89][gh-issue-89].
+
+- The RGB inspect and pretty print formats have been modified to include defined
+  names. This was suggested by @akicho8 in #89.
+
+- Added unit tests for `#pretty_print` implementations. Fixed some bugs found in
+  the implementations.
+
 ## 2.1.2 / 2025-12-30
 
 - Updated to Contributor Covenant 3.0 and applied updates to several support
@@ -15,7 +42,7 @@
   This also affected conversion from CIELAB to RGB, CMYK, HSL, YIQ, and
   grayscale, which convert from CIELAB to XYZ as an intermediate step.
 
-  Reported by @alexwlchan in [#95][issue-95] and fixed in [#96][pull-96].
+  Reported by [@alexwlchan][gh-user-alexwlchan] in [#95][issue-95] and fixed in [#96][pull-96].
 
 - Fix an incorrect comparison when converting CIE XYZ colors to RGB that could
   raise a `NoMethodError` when constructing the RGB value. The conversion
@@ -173,18 +200,18 @@ ownership to contribute it to this project under the licence terms.
 
 ## 1.7 / 2014-06-12
 
-- Added `Color::RGB::BeccaPurple` (#663399) in honour of Rebecca Meyer, the
+- Added `Color::RGB::BeccaPurple` ([#663399][gh-issue-663399]) in honour of Rebecca Meyer, the
   daughter of Eric Meyer, who passed away on 7 June 2014. Her favourite color
   was purple. `#663399becca`
   <https://www.zeldman.com/2014/06/10/the-color-purple/>
   <https://discourse.wicg.io/t/name-663399-becca-purple-in-css4-color/225/>
 
 - Changed the homepage in the gem to point to GitHub instead of RubyForge, which
-  has been shut down. Fixes [#10][issue-10], reported by @voxik.
+  has been shut down. Fixes [#10][issue-10], reported by [@voxik][gh-user-voxik].
 
 ## 1.6 / 2014-05-19
 
-- Aaron Hill (@armahillo) implemented the CIE Delta E 94 method by which an RGB
+- Aaron Hill ([@armahillo][gh-user-armahillo]) implemented the CIE Delta E 94 method by which an RGB
   color can be asked for the closest matching color from a list of provided
   colors. Fixes [#5][issue-5].
 
@@ -219,7 +246,7 @@ ownership to contribute it to this project under the licence terms.
   this work, color classes should `include` Color only need to implement
   `#coerce(other)`, `#to_a`, and supported conversion methods (e.g., `#to_rgb`).
 
-- Added @daveheitzman's initial implementation of a RGB contrast method as an
+- Added [@daveheitzman][gh-user-daveheitzman]'s initial implementation of a RGB contrast method as an
   extension file: `require 'color/rgb/contrast'`. This method and the value it
   returns should be considered experimental; it requires further examination to
   ensure that the results produced are consistent with the contrast comparisons
@@ -381,3 +408,10 @@ ownership to contribute it to this project under the licence terms.
 [pull-93]: https://github.com/halostatue/color/pull/93
 [pull-96]: https://github.com/halostatue/color/pull/96
 [wp-std-illuminant]: https://en.wikipedia.org/wiki/Standard_illuminant#White_points_of_standard_illuminants
+[gh-user-akicho8]: https://github.com/akicho8
+[gh-issue-89]: https://github.com/halostatue/color/issues/89
+[gh-user-alexwlchan]: https://github.com/alexwlchan
+[gh-issue-663399]: https://github.com/halostatue/color/issues/663399
+[gh-user-voxik]: https://github.com/voxik
+[gh-user-armahillo]: https://github.com/armahillo
+[gh-user-daveheitzman]: https://github.com/daveheitzman

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,9 +6,12 @@
 - Thomas Sawyer
 - Aaron Hill (CIE94 color matching)
 - Luke Bennellick
-- @stiff (CIELAB color support)
-- @r-plus
+- [@stiff][gh-user-stiff] (CIELAB color support)
+- [@r-plus][gh-user-r-plus]
 - Matthew Draper
 - Charles Nutter
 - Paul Gallagher
 - Alex Chan
+
+[gh-user-stiff]: https://github.com/stiff
+[gh-user-r-plus]: https://github.com/r-plus

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ reliably converted to relative color spaces (like RGB) without color profiles.
 When necessary for conversions, Color provides D65 and D50 reference white
 values in Color::XYZ.
 
-Color 2.1 fixes multiple Color::XYZ bugs. It builds on the Color 2.0 major
-release, dropping support for all versions of Ruby prior to 3.2 as well as
-removing or renaming a number of features. The main breaking changes are:
+Color 2.2 adds a minor feature where an RGB color created from values can
+silently inherit the `#name` of a predefined color if `color/rgb/colors` has
+already been loaded. It builds on the Color 2.0 major release, dropping support
+for all versions of Ruby prior to 3.2 as well as removing or renaming a number
+of features. The main breaking changes are:
 
 - Color classes are immutable Data objects; they are no longer mutable.
 - RGB named colors are no longer loaded on gem startup, but must be required

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,6 @@ require "minitest"
 require "minitest/test_task"
 
 Hoe.plugin :halostatue
-Hoe.plugin :rubygems
 
 Hoe.plugins.delete :debug
 Hoe.plugins.delete :newb
@@ -31,16 +30,16 @@ hoe = Hoe.spec "color" do
   }
 
   extra_dev_deps << ["hoe", "~> 4.0"]
-  extra_dev_deps << ["hoe-halostatue", "~> 2.1", ">= 2.1.1"]
+  extra_dev_deps << ["hoe-halostatue", "~> 3.0"]
   extra_dev_deps << ["json", ">= 0.0"]
-  extra_dev_deps << ["minitest", "~> 5.16"]
+  extra_dev_deps << ["minitest", "~> 6.0"]
   extra_dev_deps << ["minitest-autotest", "~> 1.0"]
   extra_dev_deps << ["minitest-focus", "~> 1.1"]
   extra_dev_deps << ["rake", ">= 10.0", "< 14"]
-  extra_dev_deps << ["rdoc", ">= 0.0", "< 7"]
+  extra_dev_deps << ["rdoc", ">= 6.0", "< 8"]
   extra_dev_deps << ["simplecov", "~> 0.22"]
   extra_dev_deps << ["simplecov-lcov", "~> 0.8"]
-  extra_dev_deps << ["standard", "~> 1.0"]
+  extra_dev_deps << ["standard", "~> 1.50"]
 end
 
 Minitest::TestTask.create :test

--- a/color.gemspec
+++ b/color.gemspec
@@ -6,11 +6,11 @@ Gem::Specification.new do |s|
   s.version = "2.1.2".freeze
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
-  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/color/issues", "changelog_uri" => "https://github.com/halostatue/color/blob/main/CHANGELOG.md", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/color" } if s.respond_to? :metadata=
+  s.metadata = { "bug_tracker_uri" => "https://github.com/halostatue/color/issues", "changelog_uri" => "https://github.com/halostatue/color/blob/main/CHANGELOG.md", "documentation_uri" => "https://halostatue.github.io/color/", "rubygems_mfa_required" => "true", "source_code_uri" => "https://github.com/halostatue/color" } if s.respond_to? :metadata=
   s.require_paths = ["lib".freeze]
   s.authors = ["Austin Ziegler".freeze, "Matt Lyon".freeze]
-  s.date = "2025-12-30"
-  s.description = "Color is a Ruby library to provide RGB, CMYK, HSL, and other color space manipulation support to applications that require it. It provides optional named RGB colors that are commonly supported in HTML, SVG, and X11 applications.  The Color library performs purely mathematical manipulation of the colors based on color theory without reference to device color profiles (such as sRGB or Adobe RGB). For most purposes, when working with RGB and HSL color spaces, this won't matter. Absolute color spaces (like CIE LAB and CIE XYZ) cannot be reliably converted to relative color spaces (like RGB) without color profiles. When necessary for conversions, Color provides D65 and D50 reference white values in Color::XYZ.  Color 2.1 fixes multiple Color::XYZ bugs. It builds on the Color 2.0 major release, dropping support for all versions of Ruby prior to 3.2 as well as removing or renaming a number of features. The main breaking changes are:  - Color classes are immutable Data objects; they are no longer mutable. - RGB named colors are no longer loaded on gem startup, but must be required   explicitly (this is _not_ done via `autoload` because there are more than 100   named colors with spelling variations) with `require \"color/rgb/colors\"`. - Color palettes have been removed. - `Color::CSS` and `Color::CSS#[]` have been removed.".freeze
+  s.date = "1980-01-02"
+  s.description = "Color is a Ruby library to provide RGB, CMYK, HSL, and other color space manipulation support to applications that require it. It provides optional named RGB colors that are commonly supported in HTML, SVG, and X11 applications.  The Color library performs purely mathematical manipulation of the colors based on color theory without reference to device color profiles (such as sRGB or Adobe RGB). For most purposes, when working with RGB and HSL color spaces, this won't matter. Absolute color spaces (like CIE LAB and CIE XYZ) cannot be reliably converted to relative color spaces (like RGB) without color profiles. When necessary for conversions, Color provides D65 and D50 reference white values in Color::XYZ.  Color 2.2 adds a minor feature where an RGB color created from values can silently inherit the `#name` of a predefined color if `color/rgb/colors` has already been loaded.  Color 2.1 fixes multiple Color::XYZ bugs. It builds on the Color 2.0 major release, dropping support for all versions of Ruby prior to 3.2 as well as removing or renaming a number of features. The main breaking changes are:  - Color classes are immutable Data objects; they are no longer mutable. - RGB named colors are no longer loaded on gem startup, but must be required   explicitly (this is _not_ done via `autoload` because there are more than 100   named colors with spelling variations) with `require \"color/rgb/colors\"`. - Color palettes have been removed. - `Color::CSS` and `Color::CSS#[]` have been removed.".freeze
   s.email = ["halostatue@gmail.com".freeze, "matt@postsomnia.com".freeze]
   s.extra_rdoc_files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "SECURITY.md".freeze, "licences/dco.txt".freeze]
   s.files = ["CHANGELOG.md".freeze, "CODE_OF_CONDUCT.md".freeze, "CONTRIBUTING.md".freeze, "CONTRIBUTORS.md".freeze, "LICENCE.md".freeze, "Manifest.txt".freeze, "README.md".freeze, "Rakefile".freeze, "SECURITY.md".freeze, "lib/color.rb".freeze, "lib/color/cielab.rb".freeze, "lib/color/cmyk.rb".freeze, "lib/color/grayscale.rb".freeze, "lib/color/hsl.rb".freeze, "lib/color/rgb.rb".freeze, "lib/color/rgb/colors.rb".freeze, "lib/color/version.rb".freeze, "lib/color/xyz.rb".freeze, "lib/color/yiq.rb".freeze, "licences/dco.txt".freeze, "test/fixtures/cielab.json".freeze, "test/minitest_helper.rb".freeze, "test/test_cmyk.rb".freeze, "test/test_color.rb".freeze, "test/test_grayscale.rb".freeze, "test/test_hsl.rb".freeze, "test/test_rgb.rb".freeze, "test/test_yiq.rb".freeze]
@@ -18,20 +18,20 @@ Gem::Specification.new do |s|
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]
   s.required_ruby_version = Gem::Requirement.new(">= 3.2".freeze)
-  s.rubygems_version = "3.6.9".freeze
+  s.rubygems_version = "4.0.4".freeze
   s.summary = "Color is a Ruby library to provide RGB, CMYK, HSL, and other color space manipulation support to applications that require it".freeze
 
   s.specification_version = 4
 
   s.add_development_dependency(%q<hoe>.freeze, ["~> 4.0".freeze])
-  s.add_development_dependency(%q<hoe-halostatue>.freeze, ["~> 2.1".freeze, ">= 2.1.1".freeze])
+  s.add_development_dependency(%q<hoe-halostatue>.freeze, ["~> 3.0".freeze])
   s.add_development_dependency(%q<json>.freeze, [">= 0.0".freeze])
-  s.add_development_dependency(%q<minitest>.freeze, ["~> 5.16".freeze])
+  s.add_development_dependency(%q<minitest>.freeze, ["~> 6.0".freeze])
   s.add_development_dependency(%q<minitest-autotest>.freeze, ["~> 1.0".freeze])
   s.add_development_dependency(%q<minitest-focus>.freeze, ["~> 1.1".freeze])
   s.add_development_dependency(%q<rake>.freeze, [">= 10.0".freeze, "< 14".freeze])
-  s.add_development_dependency(%q<rdoc>.freeze, [">= 0.0".freeze, "< 7".freeze])
+  s.add_development_dependency(%q<rdoc>.freeze, [">= 6.0".freeze, "< 8".freeze])
   s.add_development_dependency(%q<simplecov>.freeze, ["~> 0.22".freeze])
   s.add_development_dependency(%q<simplecov-lcov>.freeze, ["~> 0.8".freeze])
-  s.add_development_dependency(%q<standard>.freeze, ["~> 1.0".freeze])
+  s.add_development_dependency(%q<standard>.freeze, ["~> 1.50".freeze])
 end

--- a/lib/color/cmyk.rb
+++ b/lib/color/cmyk.rb
@@ -255,14 +255,13 @@ class Color::CMYK
     q.text "CMYK"
     q.breakable
     q.group 2, "[", "]" do
-      q.text ".2f%%" % cyan
+      q.text "%.2f%%" % cyan
       q.fill_breakable
-      q.text ".2f%%" % magenta
+      q.text "%.2f%%" % magenta
       q.fill_breakable
-      q.text ".2f%%" % yellow
+      q.text "%.2f%%" % yellow
       q.fill_breakable
-      q.text ".2f%%" % key
-      q.fill_breakable
+      q.text "%.2f%%" % key
     end
   end
 

--- a/lib/color/version.rb
+++ b/lib/color/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Color
-  VERSION = "2.1.2" # :nodoc:
+  VERSION = "2.2.0" # :nodoc:
 end

--- a/lib/color/xyz.rb
+++ b/lib/color/xyz.rb
@@ -260,7 +260,7 @@ class Color::XYZ
 
   def to_internal = [x, y, z] # :nodoc:
 
-  def inspect = "XYZ [#{x} #{y} #{z}]" # :nodoc:
+  def inspect = "XYZ [%.4f %.4f %.4f]" % [x, y, z] # :nodoc:
 
   def pretty_print(q) # :nodoc:
     q.text "XYZ"

--- a/lib/color/yiq.rb
+++ b/lib/color/yiq.rb
@@ -88,15 +88,15 @@ class Color::YIQ
 
   def inspect = "YIQ [%.2f%% %.2f%% %.2f%%]" % [y * 100, i * 100, q * 100] # :nodoc:
 
-  def pretty_print(q) # :nodoc:
-    q.text "YIQ"
-    q.breakable
-    q.group 2, "[", "]" do
-      q.text "%.2f%%" % y
-      q.fill_breakable
-      q.text "%.2f%%" % i
-      q.fill_breakable
-      q.text "%.2f%%" % q
+  def pretty_print(pq) # :nodoc:
+    pq.text "YIQ"
+    pq.breakable
+    pq.group 2, "[", "]" do
+      pq.text "%.2f%%" % (y * 100)
+      pq.fill_breakable
+      pq.text "%.2f%%" % (i * 100)
+      pq.fill_breakable
+      pq.text "%.2f%%" % (q * 100)
     end
   end
 

--- a/test/minitest_helper.rb
+++ b/test/minitest_helper.rb
@@ -3,6 +3,8 @@
 require "color"
 require "color/rgb/colors"
 
+require "pp"
+
 gem "minitest"
 require "minitest/autorun"
 require "minitest/focus"
@@ -16,6 +18,12 @@ end
 module Minitest::ColorExtensions
   def assert_in_tolerance(expected, actual, msg = nil)
     assert_in_delta expected, actual, Color::TOLERANCE, msg
+  end
+
+  def assert_pretty_inspect(expected, object, msg = nil)
+    actual = PP.pp(object, +"", 8)
+
+    assert_equal expected, actual, message(msg, nil) { diff expected, actual }
   end
 
   Minitest::Test.send(:include, self)

--- a/test/test_cielab.rb
+++ b/test/test_cielab.rb
@@ -91,6 +91,14 @@ module TestColor
       assert_equal(Color::YIQ.from_values(0, 0, 0), Color::CIELAB.from_values(0, 0, 0).to_yiq)
     end
 
+    def test_inspect
+      assert_equal "CIELAB [10.0000 20.0000 30.0000]", @lab.inspect
+    end
+
+    def test_pretty_print
+      assert_pretty_inspect "CIELAB\n[10.0000\n  20.0000\n  30.0000]\n", @lab
+    end
+
     def test_to_internal
       assert_equal([0.0, 0.0, 0.0], Color::CIELAB.from_values(0, 0, 0).to_internal)
     end

--- a/test/test_cmyk.rb
+++ b/test/test_cmyk.rb
@@ -34,6 +34,10 @@ module TestColor
       assert_equal("CMYK [10.00% 20.00% 30.00% 40.00%]", @cmyk.inspect)
     end
 
+    def test_pretty_print
+      assert_pretty_inspect "CMYK\n[10.00%\n  20.00%\n  30.00%\n  40.00%]\n", @cmyk
+    end
+
     def test_css
       assert_equal("device-cmyk(10.00% 20.00% 30.00% 40.00%, rgb(54.00% 48.00% 42.00%))", @cmyk.css)
       assert_equal("device-cmyk(10.00% 20.00% 30.00% 40.00% / 0.50, rgb(54.00% 48.00% 42.00% / 0.50))", @cmyk.css(alpha: 0.5))

--- a/test/test_grayscale.rb
+++ b/test/test_grayscale.rb
@@ -42,6 +42,10 @@ module TestColor
     def test_inspect
       assert_equal("Grayscale [33.00%]", @gs.inspect)
     end
+
+    def test_pretty_print
+      assert_pretty_inspect "Grayscale\n[33.00%]\n", @gs
+    end
   end
 
   class TestGrayscaleConversions < Minitest::Test

--- a/test/test_hsl.rb
+++ b/test/test_hsl.rb
@@ -82,6 +82,10 @@ module TestColor
     def test_inspect
       assert_equal "HSL [145.00deg 20.00% 30.00%]", @hsl.inspect
     end
+
+    def test_pretty_print
+      assert_pretty_inspect "HSL\n[145.00deg\n  20.00%\n  30.00%]\n", @hsl
+    end
   end
 
   class TestHSLConversions < Minitest::Test

--- a/test/test_rgb.rb
+++ b/test/test_rgb.rb
@@ -139,8 +139,8 @@ module TestColor
     def test_by_hex
       assert_same(Color::RGB::Cyan, Color::RGB.by_hex("#0ff"))
       assert_same(Color::RGB::Cyan, Color::RGB.by_hex("#00ffff"))
-      assert_equal("RGB [#333333]", Color::RGB.by_hex("#333").inspect)
-      assert_equal("RGB [#333333]", Color::RGB.by_hex("333").inspect)
+      assert_equal("RGB [#333333] {tungsten}", Color::RGB.by_hex("#333").inspect)
+      assert_equal("RGB [#333333] {tungsten}", Color::RGB.by_hex("333").inspect)
       assert_raises(ArgumentError) { Color::RGB.by_hex("5555555") }
       assert_raises(ArgumentError) { Color::RGB.by_hex("#55555") }
     end
@@ -170,11 +170,41 @@ module TestColor
     end
 
     def test_inspect
-      assert_equal("RGB [#000000]", Color::RGB::Black.inspect)
-      assert_equal("RGB [#0000ff]", Color::RGB::Blue.inspect)
-      assert_equal("RGB [#00ff00]", Color::RGB::Lime.inspect)
-      assert_equal("RGB [#ff0000]", Color::RGB::Red.inspect)
-      assert_equal("RGB [#ffffff]", Color::RGB::White.inspect)
+      assert_equal("RGB [#000000] {black}", Color::RGB::Black.inspect)
+      assert_equal("RGB [#0000ff] {blue}", Color::RGB::Blue.inspect)
+      assert_equal("RGB [#00ff00] {lime}", Color::RGB::Lime.inspect)
+      assert_equal("RGB [#ff0000] {red}", Color::RGB::Red.inspect)
+      assert_equal("RGB [#ffffff] {white}", Color::RGB::White.inspect)
+      assert_equal("RGB [#708090] {slategray slategrey}", Color::RGB::SlateGrey.inspect)
+    end
+
+    def test_pretty_print
+      assert_pretty_inspect("RGB\n[#000000]\n{black}\n", Color::RGB::Black)
+      assert_pretty_inspect("RGB\n[#0000ff]\n{blue}\n", Color::RGB::Blue)
+      assert_pretty_inspect("RGB\n[#00ff00]\n{lime}\n", Color::RGB::Lime)
+      assert_pretty_inspect("RGB\n[#ff0000]\n{red}\n", Color::RGB::Red)
+      assert_pretty_inspect("RGB\n[#ffffff]\n{white}\n", Color::RGB::White)
+      assert_pretty_inspect("RGB\n[#708090]\n{slategray\n  slategrey}\n", Color::RGB::SlateGrey)
+    end
+
+    def test_name
+      assert_equal("black", Color::RGB::Black.name)
+      assert_equal("blue", Color::RGB::Blue.name)
+      assert_equal("lime", Color::RGB::Lime.name)
+      assert_equal("red", Color::RGB::Red.name)
+      assert_equal("white", Color::RGB::White.name)
+
+      assert_equal("black", Color::RGB.from_values(0, 0, 0).name)
+      assert_equal("blue", Color::RGB.from_values(0, 0, 0xff).name)
+      assert_equal("lime", Color::RGB.from_values(0, 0xff, 0).name)
+      assert_equal("red", Color::RGB.from_values(0xff, 0, 0).name)
+      assert_equal("white", Color::RGB.from_values(0xff, 0xff, 0xff).name)
+
+      assert_equal("000", Color::RGB.from_values(0, 0, 0, ["000"]).name)
+      assert_equal("00f", Color::RGB.from_values(0, 0, 0xff, ["00f"]).name)
+      assert_equal("0f0", Color::RGB.from_values(0, 0xff, 0, ["0f0"]).name)
+      assert_equal("f00", Color::RGB.from_values(0xff, 0, 0, ["f00"]).name)
+      assert_equal("fff", Color::RGB.from_values(0xff, 0xff, 0xff, ["fff"]).name)
     end
 
     def test_delta_e2000

--- a/test/test_xyz.rb
+++ b/test/test_xyz.rb
@@ -71,6 +71,14 @@ module TestColor
       assert_equal([0.0, 0.0, 0.0], Color::XYZ.from_values(0, 0, 0).to_internal)
     end
 
+    def test_inspect
+      assert_equal "XYZ [0.0010 0.0020 0.0030]", @xyz.inspect
+    end
+
+    def test_pretty_print
+      assert_pretty_inspect "XYZ\n[0.0010\n  0.0020\n  0.0030]\n", @xyz
+    end
+
     # Regression test for https://github.com/halostatue/color/issues/92
     #
     # `Color::XYZ#to_rgb` branches on whether an intermediate value N is

--- a/test/test_yiq.rb
+++ b/test/test_yiq.rb
@@ -31,6 +31,10 @@ module TestColor
     def test_inspect
       assert_equal("YIQ [10.00% 20.00% 30.00%]", @yiq.inspect)
     end
+
+    def test_pretty_print
+      assert_pretty_inspect "YIQ\n[10.00%\n  20.00%\n  30.00%]\n", @yiq
+    end
   end
 
   class TestYIQConversions < Minitest::Test


### PR DESCRIPTION
Updates step-security/harden-runner to v2.14.2 as recommended by zizmor audit.

This was developed with the assistance of Kiro.dev